### PR TITLE
Fix contact selection in PDF form filler

### DIFF
--- a/app/controllers/donation_applications_controller.rb
+++ b/app/controllers/donation_applications_controller.rb
@@ -1,14 +1,28 @@
 class DonationApplicationsController < ApplicationController
-  include DonationApplicationsHelper
   before_action :authenticate_user!
+  before_action :set_listing
+  before_action :set_contact, only: [:create, :get_pdf]
+  before_action :set_donation_application, except: [:create]
 
   def create
     @listing = Listing.find(params[:listing_id])
     submission_status ||= "printed" if @listing.requires_pdf_form?
     submission_status ||= "emailed"
-    donation_application = DonationApplication.new(applicant: current_user, listing: @listing, submission_status: submission_status)
+    phone = @contact.phone
+    phone += (" ext: " + @contact.extension) if @contact.extension
+    @donation_application = DonationApplication.new(
+      applicant: current_user,
+      listing: @listing,
+      first_name: @contact.first_name,
+      last_name: @contact.last_name,
+      title: @contact.title,
+      email: @contact.email,
+      phone: phone,
+      fax: @contact.fax,
+      submission_status: submission_status
+      )
 
-    if donation_application.save
+    if @donation_application.save
       unless @listing.followers.include?(current_user)
         @listing.followers << current_user
       end
@@ -16,7 +30,7 @@ class DonationApplicationsController < ApplicationController
       if @listing.requires_pdf_form?
         export_pdf and return
       else
-        donation_application.update(submission_date: Time.now)
+        @donation_application.update(submission_date: Time.now)
       end
       flash[:success] = "Your application has been #{submission_status}!"
       DonationApplicationMailer.donation_request(@listing, current_user).deliver_now
@@ -29,15 +43,13 @@ class DonationApplicationsController < ApplicationController
   end
 
   def show
-    @listing = Listing.find(params[:listing_id])
     display_pdf
   end
 
   def update_mailed_submission
     listing = Listing.find(params[:listing_id])
-    donation_application = current_user.donation_applications.find_by(listing: listing)
 
-    if donation_application.update_attributes(submission_status: "mailed", submission_date: Time.now)
+    if @donation_application.update_attributes(submission_status: "mailed", submission_date: Time.now)
       flash[:success] = "Your submission status has been updated"
       DonationApplicationMailer.donation_pdf_mailed(listing, current_user).deliver_now
     else
@@ -50,9 +62,8 @@ class DonationApplicationsController < ApplicationController
 
   def approve_applicant
     listing = Listing.find(params[:listing_id])
-    donation_application = DonationApplication.find(params[:id])
 
-    if donation_application.update_attributes(approval_status: "approved")
+    if @donation_application.update_attributes(approval_status: "approved")
       flash[:success] = "Application status has been updated for #{donation_application.applicant.email}"
     else
       flash[:danger] = "Your request was unsuccessful, please try again"
@@ -62,9 +73,8 @@ class DonationApplicationsController < ApplicationController
 
   def decline_applicant
     listing = Listing.find(params[:listing_id])
-    donation_application = DonationApplication.find(params[:id])
 
-    if donation_application.update_attributes(approval_status: "declined")
+    if @donation_application.update_attributes(approval_status: "declined")
       flash[:success] = "Application status has been updated for #{donation_application.applicant.email}"
     else
       flash[:danger] = "Your request was unsuccessful, please try again"
@@ -74,9 +84,8 @@ class DonationApplicationsController < ApplicationController
 
   def reset_applicant
     listing = Listing.find(params[:listing_id])
-    donation_application = DonationApplication.find(params[:id])
 
-    if donation_application.update_attributes(approval_status: nil)
+    if @donation_application.update_attributes(approval_status: nil)
       flash[:success] = "Application status has been updated for #{donation_application.applicant.email}"
     else
       flash[:danger] = "Your request was unsuccessful, please try again"
@@ -85,8 +94,31 @@ class DonationApplicationsController < ApplicationController
   end
 
   private
+  def set_donation_application
+    @donation_application = current_user.donation_applications.find_by(listing: @listing)
+  end
+
+  def set_listing
+    @listing = Listing.find(params[:listing_id])
+  end
+
+  def set_contact
+    @contact = ContactInfo.find(params[:contact])
+  end
+
+  def get_pdf
+    DonationApplicationPdf.new(user: current_user, contact: @contact, listing: @listing).export
+  end
+
+  def export_pdf
+    send_file(get_pdf, type: 'application/pdf')
+  end
+
+  def display_pdf
+    send_file(get_pdf, disposition: 'inline', type: 'application/pdf')
+  end
 
   def donation_application_params
-    params.require(:donation_application).permit(:submission_status, :submission_date, :approval_status, :approval_status_reason)
+    params.require(:donation_application).permit(:submission_status, :submission_date, :approval_status, :approval_status_reason, :contact)
   end
 end

--- a/app/helpers/donation_applications_helper.rb
+++ b/app/helpers/donation_applications_helper.rb
@@ -1,11 +1,2 @@
 module DonationApplicationsHelper
-  def export_pdf
-    pdf_form = DonationApplicationPdf.new(user: current_user, listing: @listing).export
-    send_file(pdf_form, type: 'application/pdf')
-  end
-
-  def display_pdf
-    pdf_form = DonationApplicationPdf.new(user: current_user, listing: @listing).export
-    send_file(pdf_form, disposition: 'inline', type: 'application/pdf')
-  end
 end

--- a/app/models/donation_application.rb
+++ b/app/models/donation_application.rb
@@ -1,4 +1,19 @@
 class DonationApplication < ActiveRecord::Base
   belongs_to :applicant, class_name: "User", foreign_key: "user_id"
   belongs_to :listing
+
+  # def export_pdf
+  #   user = self.applicant
+  #   contact = user.contact_infos.find_by(email: self.email)
+  #   pdf_form = DonationApplicationPdf.new(user: user, contact: contact, listing: self.listing).export
+  #   send_file(pdf_form, type: 'application/pdf')
+  # end
+
+  # def display_pdf
+  #   user = self.applicant
+  #   contact = user.contact_infos.find_by(email: self.email)
+  #   pdf_form = DonationApplicationPdf.new(user: user, contact: contact, listing: self.listing).export
+  #   send_file(pdf_form, disposition: 'inline', type: 'application/pdf')
+  # end
+
 end

--- a/app/pdfs/donation_application_pdf.rb
+++ b/app/pdfs/donation_application_pdf.rb
@@ -4,8 +4,8 @@ class DonationApplicationPdf < FillablePdfForm
     @user = args[:user]
     @listing = args[:listing]
     @user_questionnaire = Questionnaire.find_by(name: @user.account_type)
-    address = @user.addresses.find_by(primary: true) || @user.addresses.first
-    contact = @user.contact_infos.find_by(primary: true) || @user.contact_infos.first
+    address = args[:address]
+    contact = args[:contact]
     @address = get_sanitized_attributes(address, Address.new)
     @contact = get_sanitized_attributes(contact, ContactInfo.new)
     @contact_name = "#{@contact[:first_name]} #{@contact[:last_name]}".titleize

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -37,7 +37,7 @@
                 <div class="row button-row">
                     <label class="column end">
                         Applicant Contact
-                        <select name="contact" id="contact">
+                        <select name="contact" id="contact" required>
                             <option value="">Select Contact</option>
                             <% @contact_list.each do |c| %>
                             <option value="<%= c.id %>"><%= c.first_and_last %>, <%= number_to_phone(c.phone) %></option>

--- a/db/migrate/20160712071004_add_applicant_contact_to_donation_application.rb
+++ b/db/migrate/20160712071004_add_applicant_contact_to_donation_application.rb
@@ -1,0 +1,16 @@
+class AddApplicantContactToDonationApplication < ActiveRecord::Migration
+  def change
+    change_table :donation_applications do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :title
+      t.string :phone
+      t.string :fax
+      t.string :address
+      t.string :city
+      t.string :state_zip
+      t.string :website
+      t.string :email
+    end
+  end
+end

--- a/db/migrate/20160712072919_add_email_to_contact_info.rb
+++ b/db/migrate/20160712072919_add_email_to_contact_info.rb
@@ -1,0 +1,5 @@
+class AddEmailToContactInfo < ActiveRecord::Migration
+  def change
+    add_column :contact_infos, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160411221733) do
+ActiveRecord::Schema.define(version: 20160712072919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20160411221733) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean  "primary"
+    t.string   "email"
   end
 
   add_index "contact_infos", ["user_id"], name: "index_contact_infos_on_user_id", using: :btree
@@ -96,6 +97,16 @@ ActiveRecord::Schema.define(version: 20160411221733) do
     t.datetime "updated_at",             null: false
     t.string   "submission_status"
     t.string   "approval_status"
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "title"
+    t.string   "phone"
+    t.string   "fax"
+    t.string   "address"
+    t.string   "city"
+    t.string   "state_zip"
+    t.string   "website"
+    t.string   "email"
   end
 
   create_table "followed_listings", force: :cascade do |t|


### PR DESCRIPTION
Fix bug where form filler uses account's primary contact instead of contact selected in the drop-down selection form. Extend DonationApplication to store contact info for each submission so it can be displayed later if a user needs another copy of the form.

ToDo: Upload PDFs to an asset host (AWS S3 or similar) instead of creating PDF in system files. Update DonationApplication#show to use stored PDF form instead of generating a new PDF with every request.
